### PR TITLE
Preserve status line, one additional commit

### DIFF
--- a/docs/gst123.1.txt
+++ b/docs/gst123.1.txt
@@ -125,6 +125,18 @@ A/a::
 s::
     Toggle subtitles  (only for videos).
 
+r::
+    Toggle playback direction, forward or reverse.
+
+[ ]::
+    Change playback rate to 10% faster/slower.
+
+{ }::
+    Change playback rate to 2x faster/slower.
+
+Backspace::
+    Change playback rate to normal speed, 1x.
+
 n::
     Play next file.
 

--- a/src/gst123.cc
+++ b/src/gst123.cc
@@ -519,7 +519,9 @@ struct Player : public KeyHandler
   void
   quit()
   {
-    overwrite_time_display();
+    // End with a newline to preserve the time so the user knows where they
+    // left off.
+    Msg::print ("\n");
 
     gst_element_set_state (playbin, GST_STATE_NULL);
     if (loop)

--- a/src/gst123.cc
+++ b/src/gst123.cc
@@ -166,6 +166,8 @@ struct Player : public KeyHandler
   GstState       last_state;
   string         old_tag_str;
 
+  double        playback_rate;
+
   enum
   {
     KEEP_CODEC_TAGS,
@@ -415,8 +417,24 @@ struct Player : public KeyHandler
     if (new_pos < 0)
       new_pos = 0;
 
-    gst_element_seek (playbin, 1.0, GST_FORMAT_TIME, GST_SEEK_FLAG_FLUSH, GST_SEEK_TYPE_SET,
-                      new_pos, GST_SEEK_TYPE_NONE,  GST_CLOCK_TIME_NONE);
+    // Use *_SET and a position for both start and stop, otherwise quick
+    // changes (forward, backward, forward), can leave stop_pos as the reverse
+    // start_pos and once playing forward reaches that point playback stops.
+    gint64 start_pos;
+    gint64 stop_pos;
+    if (playback_rate >= 0)
+      {
+        start_pos = new_pos;
+        stop_pos = GST_CLOCK_TIME_NONE;
+      }
+    else
+      {
+        // when playing in reverse it is from stop to start
+        start_pos = 0;
+        stop_pos = new_pos;
+      }
+    gst_element_seek (playbin, playback_rate, GST_FORMAT_TIME, GST_SEEK_FLAG_FLUSH,
+                      GST_SEEK_TYPE_SET, start_pos, GST_SEEK_TYPE_SET, stop_pos);
   }
 
   void
@@ -427,6 +445,15 @@ struct Player : public KeyHandler
 
     double new_pos_sec = cur_pos * (1.0 / GST_SECOND) + displacement;
     seek (new_pos_sec * GST_SECOND);
+  }
+
+  void
+  set_playback_rate (double rate)
+  {
+    playback_rate = rate;
+    Msg::update_status ("playback_rate %g", playback_rate);
+
+    relative_seek (0);
   }
 
   void
@@ -505,6 +532,7 @@ struct Player : public KeyHandler
 
   Player() : playbin (0), loop(0), play_position (0)
   {
+    playback_rate = 1.0;
     cols = get_columns();
   }
 };
@@ -975,6 +1003,24 @@ Player::process_input (int key)
       case '1':
         normal_size();
         break;
+      case 'r':
+        set_playback_rate (playback_rate * -1);
+        break;
+      case KEY_HANDLER_BACKSPACE:
+        set_playback_rate (1);
+        break;
+      case '[':
+        set_playback_rate (playback_rate * .90);
+        break;
+      case ']':
+        set_playback_rate (playback_rate * 1.10);
+        break;
+      case '{':
+        set_playback_rate (playback_rate / 2);
+        break;
+      case '}':
+        set_playback_rate (playback_rate * 2);
+        break;
       case '?':
         print_keyboard_help();
         break;
@@ -998,6 +1044,10 @@ Player::print_keyboard_help()
   printf ("   1                    -     normal video size (only for videos)\n");
   printf ("   A/a                  -     increase/decrease opacity by 10%% (only for videos)\n");
   printf ("   s                    -     toggle subtitles  (only for videos)\n");
+  printf ("   r                    -     reverse playback\n");
+  printf ("   [ ]                  -     playback rate 10%% faster/slower\n");
+  printf ("   { }                  -     playback rate 2x faster/slower\n");
+  printf ("   Backspace            -     playback rate 1x\n");
   printf ("   n                    -     play next file\n");
   printf ("   q                    -     quit gst123\n");
   printf ("   ?                    -     this help\n");

--- a/src/gtkinterface.cc
+++ b/src/gtkinterface.cc
@@ -142,6 +142,7 @@ GtkInterface::init (int *argc, char ***argv, KeyHandler *handler)
   key_map[GDK_Right]       = KEY_HANDLER_RIGHT;
   key_map[GDK_Up]          = KEY_HANDLER_UP;
   key_map[GDK_Down]        = KEY_HANDLER_DOWN;
+  key_map[GDK_BackSpace]   = KEY_HANDLER_BACKSPACE;
   key_map[GDK_KP_Add]      = '+';
   key_map[GDK_KP_Subtract] = '-';
 }

--- a/src/keyhandler.h
+++ b/src/keyhandler.h
@@ -21,6 +21,7 @@
 
 /* key codes for process input ; everything < 256 is plain ascii */
 enum {
+  KEY_HANDLER_BACKSPACE = 0177, // ASCII backspace
   KEY_HANDLER_UP = 300,
   KEY_HANDLER_LEFT,
   KEY_HANDLER_RIGHT,


### PR DESCRIPTION
End with a newline to preserve the time so the user knows where they left off playing.  It's also the convention to leave the cursor on a blank line, overwrite_time_display should have cleared it, but it is better to actually start a new line.