### PR TITLE
Assorted terminal fixes

### DIFF
--- a/TODO
+++ b/TODO
@@ -2,7 +2,6 @@
   * use MicroConf to parse config file
   * make it possible to have vim-like seek keys
     (configure hjkl keyboard shortcuts to arrow keys)
-- fix terminal settings after crash
 
 wishlist:
 - wav output with --wav foo.wav

--- a/src/gst123.cc
+++ b/src/gst123.cc
@@ -365,6 +365,7 @@ struct Player : public KeyHandler
           {
             string uri = uris[play_position++];
 
+            cols = get_columns();
             overwrite_time_display();
 
             if (is_image_file (uri))

--- a/src/terminal.cc
+++ b/src/terminal.cc
@@ -27,10 +27,6 @@
 #include <vector>
 #include <map>
 
-#ifdef getch
-#undef getch
-#endif
-
 #include "terminal.h"
 
 using std::vector;
@@ -71,7 +67,7 @@ Terminal::stdin_dispatch (GSource    *source,
   int key;
   do
     {
-      key = terminal_instance->getch();
+      key = terminal_instance->getchar();
 
       if (key > 0)
         terminal_instance->key_handler->process_input (key);
@@ -177,7 +173,7 @@ Terminal::read_stdin()
 }
 
 int
-Terminal::getch()
+Terminal::getchar()
 {
   for (;;)
     {

--- a/src/terminal.h
+++ b/src/terminal.h
@@ -39,7 +39,7 @@ class Terminal
   static void signal_sig_cont (int);
 
   void read_stdin();
-  int getch();
+  int getchar();
   void init_terminal();
   void bind_key (const char *key, int handler);
   void print_term (const char *key);

--- a/src/terminal.h
+++ b/src/terminal.h
@@ -28,7 +28,6 @@
 
 class Terminal
 {
-  struct termios             tio_orig;
   std::string                terminal_type;
   std::vector<int>           chars;
   std::map<std::string, int> keys;


### PR DESCRIPTION
- catch terminal resizes on track change
- rename function to avoid having to #undef getch
- use atexit() to reset terminal settings in case of crash