### PR TITLE
Allow it to run in wayland... by forcing X11

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -92,7 +92,7 @@ dnl We need libX11
 dnl
 AC_DEFUN([AC_X11_REQUIREMENTS],
 [
-    AC_CHECK_LIB(X11, XOpenDisplay)
+    AC_CHECK_LIB(X11, XInitThreads)
     X11_LIBS='-lX11'
     AC_SUBST(X11_LIBS)
 ])

--- a/src/gtkinterface.cc
+++ b/src/gtkinterface.cc
@@ -84,17 +84,6 @@ window_state_event_cb (GtkWidget *widget,
   return gtk_interface->handle_window_state_event (ws_event);
 }
 
-bool
-GtkInterface::have_x11_display()
-{
-  static Display *display = NULL;
-
-  if (!display)
-    display = XOpenDisplay (NULL);   // this should work if and only if we do have an X11 server we can use
-
-  return display != NULL;
-}
-
 GtkInterface::GtkInterface() :
   window_xid (0),
   video_width (0),
@@ -110,9 +99,8 @@ GtkInterface::init (int *argc, char ***argv, KeyHandler *handler)
 {
   key_handler = handler;
 
-  if (have_x11_display())
+  if (gtk_init_check (argc, argv))
     {
-      gtk_init (argc, argv);
       gtk_window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
       gtk_window_set_icon_name (GTK_WINDOW (gtk_window), "multimedia-player");
       g_signal_connect (G_OBJECT (gtk_window), "key-press-event", G_CALLBACK (key_press_event_cb), this);

--- a/src/gtkinterface.cc
+++ b/src/gtkinterface.cc
@@ -99,6 +99,7 @@ GtkInterface::init (int *argc, char ***argv, KeyHandler *handler)
 {
   key_handler = handler;
 
+  gdk_set_allowed_backends ("x11");
   if (gtk_init_check (argc, argv))
     {
       gtk_window = gtk_window_new (GTK_WINDOW_TOPLEVEL);

--- a/src/gtkinterface.h
+++ b/src/gtkinterface.h
@@ -70,8 +70,6 @@ public:
   void normal_size();
   void set_opacity (double alpha_change);
   void set_title (const std::string& title);
-
-  static bool have_x11_display();
 };
 
 #endif

--- a/src/options.cc
+++ b/src/options.cc
@@ -105,8 +105,7 @@ Options::parse (int argc, char **argv)
   };
   g_option_context_add_main_entries (context, all_options, NULL);
   g_option_context_add_group (context, gst_init_get_option_group());
-
-  if (GtkInterface::have_x11_display())
+  if (gtk_init_check (&argc, &argv))
     g_option_context_add_group (context, gtk_get_option_group (TRUE));
 
   GError *error = NULL;

--- a/src/options.cc
+++ b/src/options.cc
@@ -105,6 +105,8 @@ Options::parse (int argc, char **argv)
   };
   g_option_context_add_main_entries (context, all_options, NULL);
   g_option_context_add_group (context, gst_init_get_option_group());
+
+  gdk_set_allowed_backends("x11");
   if (gtk_init_check (&argc, &argv))
     g_option_context_add_group (context, gtk_get_option_group (TRUE));
 


### PR DESCRIPTION
Also use gtk_init_check to check for display.

The forcing of X11 is a stopgap (as changes to support wayland are larger.)